### PR TITLE
Improved Gradle Plugin Extension Support

### DIFF
--- a/projectguard/api/projectguard.api
+++ b/projectguard/api/projectguard.api
@@ -13,15 +13,15 @@ public final class com/rubensousa/projectguard/plugin/GuardRule {
 }
 
 public abstract interface class com/rubensousa/projectguard/plugin/GuardScope {
-	public static final field Companion Lcom/rubensousa/projectguard/plugin/GuardScope$Companion;
 	public abstract fun applyRule (Lcom/rubensousa/projectguard/plugin/GuardRule;)V
-	public fun deny (Ljava/lang/String;)V
+	public fun deny (Ljava/lang/String;Lgroovy/lang/Closure;)V
 	public abstract fun deny (Ljava/lang/String;Lorg/gradle/api/Action;)V
-	public fun deny (Lorg/gradle/api/provider/Provider;)V
+	public fun deny (Lorg/gradle/api/internal/catalog/DelegatingProjectDependency;Lorg/gradle/api/Action;)V
+	public fun deny (Lorg/gradle/api/provider/Provider;Lgroovy/lang/Closure;)V
 	public abstract fun deny (Lorg/gradle/api/provider/Provider;Lorg/gradle/api/Action;)V
-}
-
-public final class com/rubensousa/projectguard/plugin/GuardScope$Companion {
+	public static synthetic fun deny$default (Lcom/rubensousa/projectguard/plugin/GuardScope;Ljava/lang/String;Lorg/gradle/api/Action;ILjava/lang/Object;)V
+	public static synthetic fun deny$default (Lcom/rubensousa/projectguard/plugin/GuardScope;Lorg/gradle/api/internal/catalog/DelegatingProjectDependency;Lorg/gradle/api/Action;ILjava/lang/Object;)V
+	public static synthetic fun deny$default (Lcom/rubensousa/projectguard/plugin/GuardScope;Lorg/gradle/api/provider/Provider;Lorg/gradle/api/Action;ILjava/lang/Object;)V
 }
 
 public abstract interface class com/rubensousa/projectguard/plugin/ModuleRestrictionScope {
@@ -51,20 +51,24 @@ public final class com/rubensousa/projectguard/plugin/ProjectGuardPlugin : org/g
 }
 
 public abstract interface class com/rubensousa/projectguard/plugin/ProjectGuardScope {
-	public static final field Companion Lcom/rubensousa/projectguard/plugin/ProjectGuardScope$Companion;
 	public abstract fun guard (Ljava/lang/String;Lorg/gradle/api/Action;)V
+	public fun guard (Lorg/gradle/api/internal/catalog/DelegatingProjectDependency;Lorg/gradle/api/Action;)V
 	public abstract fun guardRule (Lorg/gradle/api/Action;)Lcom/rubensousa/projectguard/plugin/GuardRule;
-	public fun restrictDependency (Ljava/lang/String;)V
+	public fun restrictDependency (Ljava/lang/String;Lgroovy/lang/Closure;)V
 	public abstract fun restrictDependency (Ljava/lang/String;Lorg/gradle/api/Action;)V
-	public fun restrictDependency (Lorg/gradle/api/provider/Provider;)V
+	public fun restrictDependency (Lorg/gradle/api/internal/catalog/DelegatingProjectDependency;Lorg/gradle/api/Action;)V
+	public fun restrictDependency (Lorg/gradle/api/provider/Provider;Lgroovy/lang/Closure;)V
 	public abstract fun restrictDependency (Lorg/gradle/api/provider/Provider;Lorg/gradle/api/Action;)V
+	public static synthetic fun restrictDependency$default (Lcom/rubensousa/projectguard/plugin/ProjectGuardScope;Ljava/lang/String;Lorg/gradle/api/Action;ILjava/lang/Object;)V
+	public static synthetic fun restrictDependency$default (Lcom/rubensousa/projectguard/plugin/ProjectGuardScope;Lorg/gradle/api/internal/catalog/DelegatingProjectDependency;Lorg/gradle/api/Action;ILjava/lang/Object;)V
+	public static synthetic fun restrictDependency$default (Lcom/rubensousa/projectguard/plugin/ProjectGuardScope;Lorg/gradle/api/provider/Provider;Lorg/gradle/api/Action;ILjava/lang/Object;)V
 	public abstract fun restrictDependencyRule (Lorg/gradle/api/Action;)Lcom/rubensousa/projectguard/plugin/RestrictDependencyRule;
-	public fun restrictModule (Ljava/lang/String;)V
+	public fun restrictModule (Ljava/lang/String;Lgroovy/lang/Closure;)V
 	public abstract fun restrictModule (Ljava/lang/String;Lorg/gradle/api/Action;)V
+	public fun restrictModule (Lorg/gradle/api/internal/catalog/DelegatingProjectDependency;Lorg/gradle/api/Action;)V
+	public static synthetic fun restrictModule$default (Lcom/rubensousa/projectguard/plugin/ProjectGuardScope;Ljava/lang/String;Lorg/gradle/api/Action;ILjava/lang/Object;)V
+	public static synthetic fun restrictModule$default (Lcom/rubensousa/projectguard/plugin/ProjectGuardScope;Lorg/gradle/api/internal/catalog/DelegatingProjectDependency;Lorg/gradle/api/Action;ILjava/lang/Object;)V
 	public abstract fun restrictModuleRule (Lorg/gradle/api/Action;)Lcom/rubensousa/projectguard/plugin/RestrictModuleRule;
-}
-
-public final class com/rubensousa/projectguard/plugin/ProjectGuardScope$Companion {
 }
 
 public final class com/rubensousa/projectguard/plugin/RestrictDependencyRule {

--- a/projectguard/src/main/kotlin/com/rubensousa/projectguard/plugin/GuardScope.kt
+++ b/projectguard/src/main/kotlin/com/rubensousa/projectguard/plugin/GuardScope.kt
@@ -16,39 +16,45 @@
 
 package com.rubensousa.projectguard.plugin
 
+import groovy.lang.Closure
 import org.gradle.api.Action
 import org.gradle.api.artifacts.MinimalExternalModuleDependency
+import org.gradle.api.internal.catalog.DelegatingProjectDependency
 import org.gradle.api.provider.Provider
+import org.gradle.util.internal.ConfigureUtil
 
 interface GuardScope {
 
     fun deny(
         dependencyPath: String,
-        action: Action<DenyScope>,
+        action: Action<DenyScope> = Action<DenyScope> { },
     )
 
     fun deny(
+        dependencyDelegation: DelegatingProjectDependency,
+        action: Action<DenyScope> = Action<DenyScope> { },
+    ) = deny(dependencyPath = dependencyDelegation.path, action = action)
+
+    fun deny(
         provider: Provider<MinimalExternalModuleDependency>,
-        action: Action<DenyScope>,
+        action: Action<DenyScope> = Action<DenyScope> { },
     )
 
     // Required for groovy compatibility
     fun deny(
         dependencyPath: String,
+        closure: Closure<DenyScope>
     ) {
-        deny(dependencyPath, defaultDenyScope)
+        deny(dependencyPath, ConfigureUtil.configureUsing(closure))
     }
 
     // Required for groovy compatibility
     fun deny(
         provider: Provider<MinimalExternalModuleDependency>,
+        closure: Closure<DenyScope>
     ) {
-        deny(provider, defaultDenyScope)
+        deny(provider, ConfigureUtil.configureUsing(closure))
     }
 
     fun applyRule(rule: GuardRule)
-
-    companion object {
-        internal val defaultDenyScope = Action<DenyScope> { }
-    }
 }

--- a/projectguard/src/main/kotlin/com/rubensousa/projectguard/plugin/ProjectGuardExtension.kt
+++ b/projectguard/src/main/kotlin/com/rubensousa/projectguard/plugin/ProjectGuardExtension.kt
@@ -53,11 +53,6 @@ abstract class ProjectGuardExtension @Inject constructor(
         )
     }
 
-    override fun restrictModule(
-        moduleDelegation: DelegatingProjectDependency,
-        action: Action<ModuleRestrictionScope>
-    ) = restrictModule(modulePath = moduleDelegation.path, action = action)
-
     override fun guard(modulePath: String, action: Action<GuardScope>) {
         val scope = GuardScopeImpl()
         action.execute(scope)
@@ -68,11 +63,6 @@ abstract class ProjectGuardExtension @Inject constructor(
             )
         )
     }
-
-    override fun guard(
-        moduleDelegation: DelegatingProjectDependency,
-        action: Action<GuardScope>
-    ) = guard(modulePath = moduleDelegation.path, action = action)
 
     override fun restrictDependency(
         dependencyPath: String,
@@ -88,11 +78,6 @@ abstract class ProjectGuardExtension @Inject constructor(
             )
         )
     }
-
-    override fun restrictDependency(
-        dependencyDelegation: DelegatingProjectDependency,
-        action: Action<DependencyRestrictionScope>
-    ) = restrictDependency(dependencyPath = dependencyDelegation.path, action = action)
 
     override fun restrictDependency(
         provider: Provider<MinimalExternalModuleDependency>,

--- a/projectguard/src/main/kotlin/com/rubensousa/projectguard/plugin/ProjectGuardScope.kt
+++ b/projectguard/src/main/kotlin/com/rubensousa/projectguard/plugin/ProjectGuardScope.kt
@@ -16,10 +16,12 @@
 
 package com.rubensousa.projectguard.plugin
 
+import groovy.lang.Closure
 import org.gradle.api.Action
 import org.gradle.api.artifacts.MinimalExternalModuleDependency
 import org.gradle.api.internal.catalog.DelegatingProjectDependency
 import org.gradle.api.provider.Provider
+import org.gradle.util.internal.ConfigureUtil
 
 interface ProjectGuardScope {
 
@@ -53,17 +55,29 @@ interface ProjectGuardScope {
      */
     fun restrictModule(
         modulePath: String,
-        action: Action<ModuleRestrictionScope>,
+        action: Action<ModuleRestrictionScope> = Action<ModuleRestrictionScope> { },
     )
 
+    /**
+     * Example:
+     *
+     * Prevent a module from depending on all other dependencies
+     *
+     * ```
+     * restrictModule(projects.domain) {
+     *      // Domain modules can only depend on another domain modules
+     *      allow(":domain")
+     * }
+     * ```
+     */
     fun restrictModule(
         moduleDelegation: DelegatingProjectDependency,
-        action: Action<ModuleRestrictionScope>
-    )
+        action: Action<ModuleRestrictionScope> = Action<ModuleRestrictionScope> { }
+    ) = restrictModule(modulePath = moduleDelegation.path, action = action)
 
     // Just here for groovy support
-    fun restrictModule(modulePath: String) {
-        restrictModule(modulePath, defaultModuleRestrictionScope)
+    fun restrictModule(modulePath: String, closure: Closure<ModuleRestrictionScope>) {
+        restrictModule(modulePath, ConfigureUtil.configureUsing(closure))
     }
 
     /**
@@ -96,10 +110,20 @@ interface ProjectGuardScope {
         action: Action<GuardScope>,
     )
 
+    /**
+     * Example:
+     *
+     * ```
+     * guard(projects.domain) {
+     *      // Domain modules should not depend on UI modules
+     *      deny(":ui")
+     * }
+     * ```
+     */
     fun guard(
         moduleDelegation: DelegatingProjectDependency,
         action: Action<GuardScope>
-    )
+    ) = guard(modulePath = moduleDelegation.path, action = action)
 
     /**
      * Example:
@@ -128,13 +152,23 @@ interface ProjectGuardScope {
      */
     fun restrictDependency(
         dependencyPath: String,
-        action: Action<DependencyRestrictionScope>,
+        action: Action<DependencyRestrictionScope> = Action<DependencyRestrictionScope> { },
     )
 
+    /**
+     * Example:
+     *
+     * ```
+     * restrictDependency(projects.legacy) {
+     *      // Only legacy modules are allowed to depend on other legacy modules
+     *      allow(":legacy")
+     * }
+     * ```
+     */
     fun restrictDependency(
         dependencyDelegation: DelegatingProjectDependency,
-        action: Action<DependencyRestrictionScope>
-    )
+        action: Action<DependencyRestrictionScope> = Action<DependencyRestrictionScope> { }
+    ) = restrictDependency(dependencyPath = dependencyDelegation.path, action = action)
 
     /**
      * Example:
@@ -148,22 +182,22 @@ interface ProjectGuardScope {
      */
     fun restrictDependency(
         provider: Provider<MinimalExternalModuleDependency>,
-        action: Action<DependencyRestrictionScope>,
+        action: Action<DependencyRestrictionScope> = Action<DependencyRestrictionScope> { },
     )
 
     // Just here for groovy support
-    fun restrictDependency(dependencyPath: String) {
-        restrictDependency(dependencyPath, defaultDependencyRestrictionScope)
+    fun restrictDependency(
+        dependencyPath: String,
+        closure: Closure<DependencyRestrictionScope>
+    ) {
+        restrictDependency(dependencyPath, ConfigureUtil.configureUsing(closure))
     }
 
     // Just here for groovy support
-    fun restrictDependency(provider: Provider<MinimalExternalModuleDependency>) {
-        restrictDependency(provider, defaultDependencyRestrictionScope)
-    }
-
-    companion object {
-        private val defaultDependencyRestrictionScope = Action<DependencyRestrictionScope> {}
-        private val defaultModuleRestrictionScope = Action<ModuleRestrictionScope> {}
-
+    fun restrictDependency(
+        provider: Provider<MinimalExternalModuleDependency>,
+        closure: Closure<DependencyRestrictionScope>
+    ) {
+        restrictDependency(provider, ConfigureUtil.configureUsing(closure))
     }
 }


### PR DESCRIPTION
Adds following support:

- Passing delegated project dependecy for construction
- Proper Groovy handling

The previous groovy support always used an empty action scope which caused ignored configuration.